### PR TITLE
use sh -c export to pipe environment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ function pipeEnvironmentVariables() {
   cat > ${environmentfile} <<_EOF_
   #!/bin/sh
 _EOF_
-  export >> ${environmentfile}
+  sh -c export >> ${environmentfile}
 }
 
 if [ ! -f "${configfile}" ]; then


### PR DESCRIPTION
### Problem

Just before a job stated, I kept getting this error: `-sh: /etc/profile/d/jobber.sh: line 1: declare: not found`
### Solution

It turns out that `docker-entrypoint.sh` is being executed with bash, but the `/etc/profile.d/jobber.sh` script is being executed with sh. Under bash, the `export` command gives a output of `declare -x VARIABLE="value"` for each environment variable. This results in a script sh can't understand because sh does not know the `declare` command.

To be sure sh can understand the generated environment file, `sh -c export` should be used to export all the the environment variables. Using export trough sh gives the following output for each environment variable: `export VARIABLE='value'`
