### PR TITLE
Curl in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN export JOBBER_HOME=/tmp/jobber && \
     apk del \
       go \
       git \
-      curl \
       wget \
       make && \
     rm -rf /var/cache/apk/* && rm -rf /tmp/* && rm -rf /var/log/*


### PR DESCRIPTION
Hi, I think that curl should be by default in container because it useful to communicating between containers or for services like healthchecks.io