### PR TITLE
Update to 3.6 alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN export JOBBER_HOME=/tmp/jobber && \
       curl \
       wget \
       tzdata \
-      make && \
+      make \
+      musl-dev && \
     mkdir -p $JOBBER_HOME && \
     mkdir -p $JOBBER_LIB && \
     # Install Jobber

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM blacklabelops/alpine:3.4
+FROM blacklabelops/alpine:3.6
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
 # build parameters


### PR DESCRIPTION
Any reason why this is still using 3.4? I use this as a base for a mongdump jobber image and mongodb-tools isn't available in the 3.4 repos. I know I can set the -X flag but moving to 3.6 would also fix a few vulnerabilities with older packages.

Thanks for all of your images by the way!