### PR TITLE
Cleanup dependencies install and move tini to existing package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN export JOBBER_HOME=/tmp/jobber && \
     export CONTAINER_USER=jobber_client && \
     export CONTAINER_GROUP=jobber_client && \
     # Install tools
-    apk add --update \
+    apk add --update --no-cache --virtual .build-deps \
       go \
       git \
       curl \
@@ -43,12 +43,7 @@ RUN export JOBBER_HOME=/tmp/jobber && \
     curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && \
     chmod +x /bin/tini && \
     # Cleanup
-    apk del \
-      go \
-      git \
-      curl \
-      wget \
-      make && \
+    apk del .build-deps && \
     rm -rf /var/cache/apk/* && rm -rf /tmp/* && rm -rf /var/log/*
 
 COPY docker-entrypoint.sh /opt/jobber/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,15 +37,10 @@ RUN export JOBBER_HOME=/tmp/jobber && \
     fi && \
     make -C src/github.com/dshearer/jobber install DESTDIR=$JOBBER_HOME && \
     cp $JOBBER_LIB/bin/* /usr/bin && \
-    # Install Tini Zombie Reaper And Signal Forwarder
-    export TINI_VERSION=0.9.0 && \
-    export TINI_SHA=fa23d1e20732501c3bb8eeeca423c89ac80ed452 && \
-    curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && \
-    chmod +x /bin/tini && \
     # Cleanup
     apk del .build-deps && \
     rm -rf /var/cache/apk/* && rm -rf /tmp/* && rm -rf /var/log/*
 
 COPY docker-entrypoint.sh /opt/jobber/docker-entrypoint.sh
-ENTRYPOINT ["/bin/tini","--","/opt/jobber/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini","--","/opt/jobber/docker-entrypoint.sh"]
 CMD ["jobberd"]


### PR DESCRIPTION
Added --no-cache flag to keep the layer small and also use the --virtual flag to make cleanup easier later on. Only thing I'm unsure of is whether tzdata is needed in the running state, I'll test this now.

For tini, would you be open to using the provided package under /sbin? Your base alpine image already sets that up.